### PR TITLE
Improve Completer

### DIFF
--- a/editor.py
+++ b/editor.py
@@ -17,6 +17,8 @@ def _parseCommandLine():
     parser.add_argument('-q, --quit', action='store_true', dest='quit', help='Quit just after start')
     parser.add_argument('-l, --language', action='store_true', dest='show_language',
                         help='Print detected language when starting')
+    parser.add_argument('-c, --completions', dest='completions',
+                        help='A comma separated list of additional word completions')
     parser.add_argument('file', help='File to open')
 
     return parser.parse_args()
@@ -83,6 +85,9 @@ def main():
     qpart.detectSyntax(sourceFilePath=ns.file, firstLine=firstLine)
     if ns.show_language:
         print("Language:", qpart.language())
+
+    completions = {c.strip() for c in ns.completions.split(',')}
+    qpart.setCustomCompletions(completions)
 
     qpart.lineLengthEdge = 20
 

--- a/qutepart/__init__.py
+++ b/qutepart/__init__.py
@@ -770,6 +770,8 @@ class Qutepart(QPlainTextEdit):
         if syntax is not None:
             self._highlighter = SyntaxHighlighter(syntax, self)
             self._indenter.setSyntax(syntax)
+            keywords = {kw for kwList in syntax.parser.lists.values() for kw in kwList}
+            self._completer.setKeywords(keywords)
 
         newLanguage = self.language()
         if oldLanguage != newLanguage:

--- a/qutepart/__init__.py
+++ b/qutepart/__init__.py
@@ -798,6 +798,17 @@ class Qutepart(QPlainTextEdit):
         else:
             return self._highlighter.syntax().name
 
+    def setCustomCompletions(self, wordSet):
+        """Add a set of custom completions to the editors completions.
+
+        This set is managed independently of the set of keywords and words from
+        the current document, and can thus be changed at any time.
+
+        """
+        if not isinstance(wordSet, set):
+            raise TypeError('"wordSet" is not a set: %s' % type(wordSet))
+        self._completer.setCustomCompletions(wordSet)
+
     def isHighlightingInProgress(self):
         """Check if text highlighting is still in progress
         """

--- a/qutepart/completer.py
+++ b/qutepart/completer.py
@@ -342,6 +342,7 @@ class Completer(QObject):
         self._widget = None
         self._completionOpenedManually = False
 
+        self._keywords = set()
         self._wordSet = None
 
         qpart.textChanged.connect(self._onTextChanged)
@@ -351,6 +352,10 @@ class Completer(QObject):
         """Object deleted. Cancel timer
         """
         self._globalUpdateWordSetTimer.cancel(self._updateWordSet)
+
+    def setKeywords(self, keywords):
+        self._keywords = keywords
+        self._updateWordSet()
 
     def isVisible(self):
         return self._widget is not None
@@ -366,7 +371,7 @@ class Completer(QObject):
     def _updateWordSet(self):
         """Make a set of words, which shall be completed, from text
         """
-        self._wordSet = set()
+        self._wordSet = set(self._keywords)
 
         start = time.time()
 

--- a/qutepart/completer.py
+++ b/qutepart/completer.py
@@ -343,6 +343,7 @@ class Completer(QObject):
         self._completionOpenedManually = False
 
         self._keywords = set()
+        self._customCompletions = set()
         self._wordSet = None
 
         qpart.textChanged.connect(self._onTextChanged)
@@ -356,6 +357,9 @@ class Completer(QObject):
     def setKeywords(self, keywords):
         self._keywords = keywords
         self._updateWordSet()
+
+    def setCustomCompletions(self, wordSet):
+        self._customCompletions = wordSet
 
     def isVisible(self):
         return self._widget is not None
@@ -371,7 +375,7 @@ class Completer(QObject):
     def _updateWordSet(self):
         """Make a set of words, which shall be completed, from text
         """
-        self._wordSet = set(self._keywords)
+        self._wordSet = set(self._keywords) | set(self._customCompletions)
 
         start = time.time()
 


### PR DESCRIPTION
This PR adds two new features to the built-in completer:

1. Extract the list of keywords from a language definition and add them to the completer’s keywords. This would, for example, allow auto-completion of Python exceptions, built-ins and keywords.

2. Let the user define an additional set of completions. This is especially useful if you have an editor for keyword-less languages with a fixed structure, e.g. YAML files for Ansible or Travis (`qpart.setCustomCompletions({'sudo', 'addons', 'sources', 'matrix', 'os'})`).

Both sets of completions are managed independently (from another and from the completions derived from the current document). So the custom completions “survive” if you change the language definition or the change of the entire document. You can also reset the custom completions at any time (`qpart.setCustomCompletions(set())`).