### PR TITLE
Making the editor component more configurable: on/off mark area, on/off line numbers, on/off completer, c/python syntax parser

### DIFF
--- a/qutepart/__init__.py
+++ b/qutepart/__init__.py
@@ -271,9 +271,9 @@ class Qutepart(QPlainTextEdit):
     _globalSyntaxManager = SyntaxManager()
 
     def __init__(self,
-                 need_mark_area=True,
-                 need_line_numbers=True,
-                 need_completer=True,
+                 needMarkArea=True,
+                 needLineNumbers=True,
+                 needCompleter=True,
                  *args):
         QPlainTextEdit.__init__(self, *args)
 
@@ -318,7 +318,7 @@ class Qutepart(QPlainTextEdit):
         self.completionThreshold = self._DEFAULT_COMPLETION_THRESHOLD
         self.completionEnabled = self._DEFAULT_COMPLETION_ENABLED
         self._completer = None
-        if need_completer:
+        if needCompleter:
             self._completer = Completer(self)
 
         self._vim = None
@@ -328,9 +328,9 @@ class Qutepart(QPlainTextEdit):
         self._margins = []
         self._totalMarginWidth = -1
 
-        if need_line_numbers:
+        if needLineNumbers:
             self.addMargin(qutepart.sideareas.LineNumberArea(self))
-        if need_mark_area:
+        if needMarkArea:
             self.addMargin(qutepart.sideareas.MarkArea(self))
 
         self._nonVimExtraSelections = []

--- a/qutepart/syntax/loader.py
+++ b/qutepart/syntax/loader.py
@@ -1,6 +1,7 @@
 """This module is a set of functions, which load Parser from Kate XML files
 """
 
+import os
 import copy
 import sys
 import xml.etree.ElementTree
@@ -16,13 +17,17 @@ from PyQt5.QtGui import QTextCharFormat, QColor, QFont
 
 _logger = logging.getLogger('qutepart')
 
-try:
-    import qutepart.syntax.cParser as _parserModule
-    binaryParserAvailable = True
-except ImportError:
-    _logger.warning('Failed to import quick parser in C. Using slow parser for syntax highlighting')
+# See the Qutepart.__init__() documentation about the syntax parser selection
+binaryParserAvailable = False
+if os.environ.get('QPART_CPARSER', 'Y') == 'Y':
+    try:
+        import qutepart.syntax.cParser as _parserModule
+        binaryParserAvailable = True
+    except ImportError:
+        _logger.warning('Failed to import quick parser in C. Using slow parser for syntax highlighting')
+
+if binaryParserAvailable == False:
     import qutepart.syntax.parser as _parserModule
-    binaryParserAvailable = False
 
 
 _seqReplacer = re.compile('\\\\.')

--- a/qutepart/syntax/loader.py
+++ b/qutepart/syntax/loader.py
@@ -19,7 +19,7 @@ _logger = logging.getLogger('qutepart')
 
 # See the Qutepart.__init__() documentation about the syntax parser selection
 binaryParserAvailable = False
-if os.environ.get('QPART_CPARSER', 'Y') in ('Y', 'y', 1):
+if os.environ.get('QPART_CPARSER', 'Y') in ('Y', 'y', '1'):
     try:
         import qutepart.syntax.cParser as _parserModule
         binaryParserAvailable = True

--- a/qutepart/syntax/loader.py
+++ b/qutepart/syntax/loader.py
@@ -19,7 +19,7 @@ _logger = logging.getLogger('qutepart')
 
 # See the Qutepart.__init__() documentation about the syntax parser selection
 binaryParserAvailable = False
-if os.environ.get('QPART_CPARSER', 'Y') == 'Y':
+if os.environ.get('QPART_CPARSER', 'Y') in ('Y', 'y', 1):
     try:
         import qutepart.syntax.cParser as _parserModule
         binaryParserAvailable = True


### PR DESCRIPTION
The pull request is to provide more configurable options for the editor component keeping the backward compatibility.

* Syntax parser choice
The parser is a global object and an import happens at the top level of the module. Thus it is impossible to make the choice on the per editor basis. So there is no need for the Qutepart.__init__(...) parameter to configure the parser. The chosen solution to use an environment variable to control the parser choice does not look as the best however it has benefits too. It is simple, it keeps the backward compatibility and works well. On the negative side it is not explicit as a function call would be and requires to be careful where to set the variable in the user code so that it is for sure before the first import of the qutepart component

* Margins and completer
In some cases this functionality is not needed and it is not a tidy code to disable everything. On top of it the corresponding subclasses setup timers, do some not needed work and allocate some not needed data. It looks nicer if the user is able to explicitly enable/disable some features. So a few Qutepart.__init__(...) arguments were added so that the backward compatibility is preserved.