### PR TITLE
Add setDocument methods

### DIFF
--- a/qutepart/__init__.py
+++ b/qutepart/__init__.py
@@ -1130,6 +1130,11 @@ class Qutepart(QPlainTextEdit):
         else:
             super(Qutepart, self).mouseMoveEvent(mouseEvent)
 
+    def setDocument(self, document):
+        self._completer.terminate()
+        self._lines.setDocument(document)
+        super().setDocument(document)
+
     def _chooseVisibleWhitespace(self, text):
         result = [False for _ in range(len(text))]
 

--- a/qutepart/lines.py
+++ b/qutepart/lines.py
@@ -18,6 +18,9 @@ class Lines:
         self._qpart = qpart
         self._doc = qpart.document()
 
+    def setDocument(self, document):
+        self._doc = document
+
     def _atomicModification(func):
         """Decorator
         Make document modification atomic


### PR DESCRIPTION
This way, Qutepart won't crash when setting a new document to the QPlainTextEdit.