### PR TITLE
fix Python 3.9 incompatibility

### DIFF
--- a/qutepart/syntax/loader.py
+++ b/qutepart/syntax/loader.py
@@ -202,7 +202,7 @@ def _loadChildRules(context, xmlElement, attributeToFormatMap):
     """Extract rules from Context or Rule xml element
     """
     rules = []
-    for ruleElement in xmlElement.getchildren():
+    for ruleElement in xmlElement:
         if not ruleElement.tag in _ruleClassDict:
             raise ValueError("Not supported rule '%s'" % ruleElement.tag)
         rule = _ruleClassDict[ruleElement.tag](context, ruleElement, attributeToFormatMap)


### PR DESCRIPTION
Remove call to Element.getchildren which was removed in Python 3.9.
This method was deprecated since 3.2, though only warned in 3.8: https://docs.python.org/3.8/library/xml.etree.elementtree.html#xml.etree.ElementTree.Element.getchildren