### PR TITLE
Fix SyntaxManager test

### DIFF
--- a/tests/test_syntax/test_xml_definition_parsing.py
+++ b/tests/test_syntax/test_xml_definition_parsing.py
@@ -22,7 +22,7 @@ class XmlParsingTestCase(unittest.TestCase):
         xmlFilesPath = os.path.join(os.path.dirname(__file__), '..', '..', 'qutepart', 'syntax', 'data', 'xml')
         for xmlFileName in os.listdir(xmlFilesPath):
             if xmlFileName.endswith('.xml'):
-                syntax = SyntaxManager().getSyntax(None, xmlFileName = xmlFileName)
+                syntax = SyntaxManager().getSyntax(xmlFileName = xmlFileName)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
First argument was `formatConverterFunction = None` and it was removed in this commit

https://github.com/andreikop/qutepart/commit/d54ad12d6b80df544a86a6c58b539b17cb21fb48

    TypeError: getSyntax() got multiple values for argument 'xmlFileName'